### PR TITLE
Adiciona validação para licitação

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__
 .idea
 .scrapy/
 .vscode
+.env
 
 # data
 *.json

--- a/scraper/scraper/items.py
+++ b/scraper/scraper/items.py
@@ -1,21 +1,24 @@
 import scrapy
 
 
-class LegacyGazetteItem(scrapy.Item):
+class BaseItem(scrapy.Item):
+    crawled_at = scrapy.Field()
+    crawled_from = scrapy.Field()
+
+
+class LegacyGazetteItem(BaseItem):
     title = scrapy.Field()
     published_on = scrapy.Field()
     date = scrapy.Field()
     details = scrapy.Field()
     file_urls = scrapy.Field()
-    crawled_at = scrapy.Field()
     file_content = scrapy.Field()
 
 
-class GazetteEventItem(scrapy.Item):
+class GazetteEventItem(BaseItem):
     date = scrapy.Field()
     power = scrapy.Field()
     year_and_edition = scrapy.Field()
-    crawled_at = scrapy.Field()
     event_title = scrapy.Field()
     event_secretariat = scrapy.Field()
     event_summary = scrapy.Field()
@@ -23,15 +26,14 @@ class GazetteEventItem(scrapy.Item):
     file_content = scrapy.Field()
 
 
-class CityCouncilAgendaItem(scrapy.Item):
-    crawled_at = scrapy.Field()
+class CityCouncilAgendaItem(BaseItem):
     date = scrapy.Field()
     details = scrapy.Field()
     title = scrapy.Field()
     event_type = scrapy.Field()
 
 
-class CityHallContractItem(scrapy.Item):
+class CityHallContractItem(BaseItem):
     contract_id = scrapy.Field()
     starts_at = scrapy.Field()
     summary = scrapy.Field()
@@ -39,5 +41,17 @@ class CityHallContractItem(scrapy.Item):
     contractor_name = scrapy.Field()
     value = scrapy.Field()
     ends_at = scrapy.Field()
+    file_urls = scrapy.Field()
+    file_content = scrapy.Field()
+
+
+class CityHallBidItem(BaseItem):
+    category = scrapy.Field()
+    month = scrapy.Field()
+    year = scrapy.Field()
+    description = scrapy.Field()
+    history = scrapy.Field()
+    modality = scrapy.Field()
+    date = scrapy.Field()
     file_urls = scrapy.Field()
     file_content = scrapy.Field()

--- a/scraper/scraper/pipelines.py
+++ b/scraper/scraper/pipelines.py
@@ -1,14 +1,35 @@
 from scraper.settings import FILES_STORE, KEEP_FILES
 import os
 
+import hashlib
+from scrapy.utils.python import to_bytes
+from six.moves.urllib.parse import urlparse
+
 from scrapy.pipelines.files import FilesPipeline
 from tika import parser
 
 
 class ExtractPDFContentPipeline(FilesPipeline):
+    def file_path(self, request, response=None, info=None):
+        """Retorna onde o arquivo foi baixado.
+
+        Copiado de https://github.com/okfn-brasil/diario-oficial/
+        Issue no scrapy: https://github.com/scrapy/scrapy/issues/4225
+
+        de:
+        8e61990b27c6158edaaa715ea76eca65459d92f4.asp?cat=PMFS&dt=03-2016
+        para:
+        8e61990b27c6158edaaa715ea76eca65459d92f4.asp
+        """
+        url = request.url
+        media_guid = hashlib.sha1(to_bytes(url)).hexdigest()
+        media_ext = os.path.splitext(url)[1]
+        if not media_ext.isalnum():
+            media_ext = os.path.splitext(urlparse(url).path)[1]
+        return "full/%s%s" % (media_guid, media_ext)
+
     def item_completed(self, results, item, info):
-        if results:
-            # FIXME supports only one file by now
+        if results and results[0][0]:
             file_info = results[0][1]
             file_path = f"{FILES_STORE}{file_info['path']}"
             raw = parser.from_file(file_path)

--- a/scraper/scraper/settings.py
+++ b/scraper/scraper/settings.py
@@ -1,6 +1,7 @@
 import os
 from .items import (
     CityCouncilAgendaItem,
+    CityHallBidItem,
     CityHallContractItem,
     GazetteEventItem,
     LegacyGazetteItem,
@@ -36,4 +37,5 @@ SPIDERMON_VALIDATION_MODELS = {
     GazetteEventItem: "scraper.validators.GazetteEventItem",
     CityCouncilAgendaItem: "scraper.validators.CityCouncilAgendaItem",
     CityHallContractItem: "scraper.validators.CityHallContractItem",
+    CityHallBidItem: "scraper.validators.CityHallBidItem",
 }

--- a/scraper/scraper/spiders/citycouncil.py
+++ b/scraper/scraper/spiders/citycouncil.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from scraper.items import CityCouncilAgendaItem
+
 import scrapy
 
 
@@ -48,7 +50,8 @@ class AgendaSpider(scrapy.Spider):
             ]
 
             yield CityCouncilAgendaItem(
-                crawled_at=response.url,
+                crawled_at=datetime.now(),
+                crawled_from=response.url,
                 date=date,
                 details=" ".join(events),
                 title=title.strip(),

--- a/scraper/scraper/spiders/cityhall.py
+++ b/scraper/scraper/spiders/cityhall.py
@@ -17,7 +17,10 @@ class BidsSpider(scrapy.Spider):
         for url in urls:
             if base_url not in url:
                 # all years except 2017 and 2018
-                url = response.urljoin(f"{base_url}/seadm/{url}")
+                if url.startswith("servicos.asp"):
+                    url = response.urljoin(f"{base_url}/{url}")
+                else:
+                    url = response.urljoin(f"{base_url}/seadm/{url}")
             yield response.follow(url, self.parse_page)
 
     def parse_page(self, response):

--- a/scraper/scraper/spiders/gazette.py
+++ b/scraper/scraper/spiders/gazette.py
@@ -1,6 +1,6 @@
+from datetime import datetime
 import scrapy
 from scrapy import Request
-
 from scraper.items import GazetteEventItem, LegacyGazetteItem
 from .utils import replace_query_param
 
@@ -32,7 +32,8 @@ class LegacyGazetteSpider(scrapy.Spider):
                     date=event["date"],
                     details=url["details"],
                     file_urls=[url["url"]],
-                    crawled_at=response.url,
+                    crawled_at=datetime.now(),
+                    crawled_from=response.url,
                 )
 
             current_page = self.get_current_page(response)
@@ -169,10 +170,11 @@ class ExecutiveAndLegislativeGazetteSpider(scrapy.Spider):
                         date=gazette["date"],
                         power=gazette["power"],
                         year_and_edition=gazette["year_and_edition"],
-                        crawled_at=response.url,
                         event_title=event["title"],
                         event_secretariat=event["secretariat"],
                         event_summary=event["summary"],
+                        crawled_at=datetime.now(),
+                        crawled_from=response.url,
                     )
                     yield Request(
                         gazette["file_url"],

--- a/scraper/scraper/validators.py
+++ b/scraper/scraper/validators.py
@@ -1,23 +1,34 @@
 from schematics.models import Model
-from schematics.types import DateType, ListType, StringType, URLType
+from schematics.types import (
+    DateType,
+    DateTimeType,
+    DictType,
+    IntType,
+    ListType,
+    StringType,
+    URLType,
+)
 
 
-class LegacyGazetteItem(Model):
+class BaseModel(Model):
+    crawled_at = DateTimeType(required=True)
+    crawled_from = URLType(required=True)
+
+
+class LegacyGazetteItem(BaseModel):
     title = StringType(required=True)
     published_on = StringType(required=False)
     # important info but not available in years like 2010
     date = DateType(required=False, formats=("%d/%m/%Y", "%d/%m/%y"))
     details = StringType(required=True)
     file_urls = ListType(URLType)
-    crawled_at = URLType(required=True)
     file_content = StringType()
 
 
-class GazetteEventItem(Model):
+class GazetteEventItem(BaseModel):
     date = DateType(formats=("%d/%m/%Y", "%d/%m/%y"))
     power = StringType(required=True)
     year_and_edition = StringType(required=True)
-    crawled_at = URLType(required=True)
     event_title = StringType(required=True)
     event_secretariat = StringType(required=True)
     event_summary = StringType(required=True)
@@ -25,15 +36,14 @@ class GazetteEventItem(Model):
     file_content = StringType()
 
 
-class CityCouncilAgendaItem(Model):
-    crawled_at = URLType(required=True)
+class CityCouncilAgendaItem(BaseModel):
     date = DateType(formats=("%d/%m/%Y", "%d/%m/%y"))
     details = StringType()
     title = StringType(required=True)
     event_type = StringType(required=True)
 
 
-class CityHallContractItem(Model):
+class CityHallContractItem(BaseModel):
     contract_id = StringType(required=True)
     starts_at = DateType(formats=("%d/%m/%Y", "%d/%m/%y"))
     summary = StringType()
@@ -42,4 +52,16 @@ class CityHallContractItem(Model):
     value = StringType()
     ends_at = DateType(formats=("%d/%m/%Y", "%d/%m/%y"))
     file_urls = ListType(StringType)  # TODO check URL type
+    file_content = StringType()
+
+
+class CityHallBidItem(BaseModel):
+    category = StringType()
+    month = IntType(min_value=1, max_value=12)
+    year = IntType(min_value=1873)  # quando Feira virou cidade :)
+    description = StringType()
+    history = ListType(DictType(StringType))
+    modality = StringType()
+    date = DateTimeType(formats=("%d/%m/%Y %Hh%M"))
+    file_urls = ListType(StringType)
     file_content = StringType()


### PR DESCRIPTION
Nesse PR:

- [x] Adiciona validação (https://github.com/DadosAbertosDeFeira/maria-quiteria/issues/11)
- [x] Faz download e extrai conteúdo das licitações (fixes https://github.com/DadosAbertosDeFeira/maria-quiteria/issues/15)

Também:
- [x] Adiciona `crawled_at` e `crawled_from` todos os spiders
- [x] Corrige URL das licitações de 2019

Lidar com arquivos .rar ainda precisa ser resolvido (https://github.com/DadosAbertosDeFeira/maria-quiteria/issues/13). Atualmente o tika consegue ler arquivos PDF de dentro do .rar mas a qualidade dessa leitura e a relação com diversos arquivos precisa ser melhor testada.