### PR TITLE
Retira conteúdo do arquivo da saída dos crawlers

### DIFF
--- a/scraper/scraper/items.py
+++ b/scraper/scraper/items.py
@@ -8,7 +8,7 @@ class BaseItem(scrapy.Item):
     def __repr__(self):
         copy = self.deepcopy()
         if copy.get("file_content"):
-            preview = copy["file_content"][:200].strip()
+            preview = copy["file_content"].strip()[:200]
             copy["file_content"] = f"Preview: {preview}"
         return super(BaseItem, copy).__repr__()
 

--- a/scraper/scraper/items.py
+++ b/scraper/scraper/items.py
@@ -5,6 +5,13 @@ class BaseItem(scrapy.Item):
     crawled_at = scrapy.Field()
     crawled_from = scrapy.Field()
 
+    def __repr__(self):
+        copy = self.deepcopy()
+        if copy.get("file_content"):
+            preview = copy["file_content"][:200].strip()
+            copy["file_content"] = f"Preview: {preview}"
+        return super(BaseItem, copy).__repr__()
+
 
 class LegacyGazetteItem(BaseItem):
     title = scrapy.Field()

--- a/scraper/scraper/pipelines.py
+++ b/scraper/scraper/pipelines.py
@@ -8,7 +8,7 @@ from six.moves.urllib.parse import urlparse
 from tika import parser
 
 
-class ExtractPDFContentPipeline(FilesPipeline):
+class ExtractFileContentPipeline(FilesPipeline):
     def file_path(self, request, response=None, info=None):
         """Retorna onde o arquivo foi baixado.
 

--- a/scraper/scraper/settings.py
+++ b/scraper/scraper/settings.py
@@ -23,7 +23,7 @@ SENTRY_DSN = os.getenv("SENTRY_DSN", "")
 
 # pipelines
 ITEM_PIPELINES = {
-    "scraper.pipelines.ExtractPDFContentPipeline": 100,
+    "scraper.pipelines.ExtractFileContentPipeline": 100,
     "spidermon.contrib.scrapy.pipelines.ItemValidationPipeline": 200,
 }
 FILES_STORE = f"{os.getcwd()}/data/"


### PR DESCRIPTION
O conteúdo dos arquivos é exibido junto com outros campos dos itens. Por vezes os arquivos tem muitas páginas, o que pode causar um problema de memória desnecessário. O conteúdo dos arquivos continua sendo salvo ao exportar como JSON ou CSV, por exemplo, mas no output é exibido apenas os 200 primeiros caracteres.