### PR TITLE
Usar versão binária do `psycopg2`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django==3.0.3
 django-configurations==2.2
 gunicorn==20.0.4
 jinja2==2.11.1
-psycopg2==2.8.4
+psycopg2-binary==2.8.4
 schematics==2.1.0
 scrapy==1.8.0
 sentry-sdk==0.14.2


### PR DESCRIPTION
A versão atual da psycopg2 requer compilação na máquina, o que leva a mais pacotes instalados. Ou o próprio postgresql instalado na máquina.

O pacote em sua versão `psycopg2-binary` já contém tudo que a lib precisa para rodar o cliente.

Mais informações aqui: https://www.psycopg.org/docs/install.html#build-prerequisites