### PR TITLE
Checa se conseguiu extrair a data antes de criar nota

### DIFF
--- a/datasets/management/commands/_gazette.py
+++ b/datasets/management/commands/_gazette.py
@@ -41,11 +41,12 @@ def save_legacy_gazette(item):
     tentativa de extrair a data do título.
     """
 
+    notes = ""
     if item["date"] is None:
-        item["date"] = _extract_date(item["title"])
-        notes = "Data extraída do título."
-    else:
-        notes = ""
+        extracted_date = _extract_date(item["title"])
+        if extracted_date:
+            item["date"] = extracted_date
+            notes = "Data extraída do título."
 
     gazette, _ = Gazette.objects.get_or_create(
         date=item["date"],

--- a/datasets/management/commands/_gazette.py
+++ b/datasets/management/commands/_gazette.py
@@ -74,7 +74,7 @@ def save_legacy_gazette(item):
 def _extract_date(str_date):
     if str_date is None:
         return
-    pattern = r"(\d{2}) DE (\w+) DE (\d{4})"
+    pattern = r"(\d+) DE (\w+) DE (\d{4})"
     result = re.search(pattern, str_date, re.IGNORECASE)
     if result:
         months = {

--- a/datasets/tests/management/commands/test_gazette.py
+++ b/datasets/tests/management/commands/test_gazette.py
@@ -220,6 +220,7 @@ class TestSaveLegacyGazette:
         gazettes = [save_legacy_gazette(legacy_item) for legacy_item in legacy_items]
 
         assert len(set([g.pk for g in gazettes])) == 3
+        assert gazettes[0].date == date(2014, 11, 1)
         assert gazettes[0].notes == "Data extraída do título."
 
 


### PR DESCRIPTION
Alguns diários não tem datas em seus títulos (especialmente os legados). Em 543 diários é possível extrair a data dos títulos. Para outros quase 3 mil, não. Esse PR corrige bug que adicionava uma nota "Data extraída do título" para diários sem data.