### PR TITLE
Corrige data início da coleta para licitação

### DIFF
--- a/datasets/baker_recipes.py
+++ b/datasets/baker_recipes.py
@@ -5,6 +5,7 @@ from datasets.models import (
     CityCouncilAttendanceList,
     CityCouncilExpense,
     CityCouncilMinute,
+    CityHallBid,
     Gazette,
     GazetteEvent,
 )
@@ -38,3 +39,6 @@ Gazette = Recipe(Gazette,)
 
 
 GazetteEvent = Recipe(GazetteEvent, gazette=foreign_key(Gazette))
+
+
+CityHallBid = Recipe(CityHallBid)

--- a/datasets/models.py
+++ b/datasets/models.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
@@ -231,6 +231,22 @@ class CityHallBid(DatasetMixin):
 
     def __str__(self):
         return f"{self.session_at} {self.modality} {self.public_agency}"
+
+    @classmethod
+    def last_collected_item_date(cls):
+        """Retorna data para início da coleta.
+
+        Dado que as licitações são constantemente atualizadas e nós não temos
+        um maneira mais simples de verificar os últimos itens atualizados,
+        vamos assumir que os últimos seis meses é um período razoável para
+        ter licitações sendo atualizadas.
+        """
+        try:
+            # checa se existe algum registro antes
+            cls.objects.latest()
+            return date.today() - timedelta(days=180)
+        except cls.DoesNotExist:
+            return
 
 
 class CityHallBidEvent(DatasetMixin):

--- a/datasets/tests/test_models.py
+++ b/datasets/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, timedelta
 
 import pytest
 from model_bakery import baker
@@ -69,3 +69,15 @@ class TestGazette:
         expected_date = date(2019, 10, 1)
         gazette = baker.make_recipe("datasets.Gazette", date=expected_date,)
         assert gazette.last_collected_item_date() == expected_date
+
+
+@pytest.mark.django_db
+class TestCityHallBid:
+    def test_return_none_for_last_collected_item_date_if_nothing_is_found(self):
+        bid = baker.prepare_recipe("datasets.CityHallBid")
+        assert bid.last_collected_item_date() is None
+
+    def test_last_collected_item_date_is_six_months_ago(self):
+        expected_date = date.today() - timedelta(days=180)
+        bid = baker.make_recipe("datasets.CityHallBid")
+        assert bid.last_collected_item_date() == expected_date


### PR DESCRIPTION
As licitações tem uma forma diferente de atualização. Não temos registro da última vez em que foram modificadas ou movidas. Por isso, a data inicial para coleta será 6 meses atrás - período de tempo grande o suficiente para o processo ter sido concluído e sofrer alterações (ACHO :) ).