### PR TITLE
Sempre que arquivo for salvo verifica se tem backup e contéudo extraído

### DIFF
--- a/datasets/apps.py
+++ b/datasets/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class DatasetsConfig(AppConfig):
     name = "datasets"
     verbose_name = "Bases de dados"
+
+    def ready(self):
+        import datasets.signals  # noqa

--- a/datasets/baker_recipes.py
+++ b/datasets/baker_recipes.py
@@ -9,6 +9,7 @@ from datasets.models import (
     CityCouncilMinute,
     CityCouncilRevenue,
     CityHallBid,
+    File,
     Gazette,
     GazetteEvent,
 )
@@ -54,3 +55,6 @@ Gazette = Recipe(Gazette,)
 
 
 GazetteEvent = Recipe(GazetteEvent, gazette=foreign_key(Gazette))
+
+
+File = Recipe(File,)

--- a/datasets/management/commands/_file.py
+++ b/datasets/management/commands/_file.py
@@ -1,24 +1,7 @@
 from datasets.models import File
-from datasets.tasks import backup_file, content_from_file
-from django.conf import settings
-from dramatiq import pipeline
 
 
 def save_file(url, content_type, object_id, checksum=None):
-    file_, created = File.objects.get_or_create(
+    File.objects.get_or_create(
         url=url, content_type=content_type, object_id=object_id, checksum=checksum,
     )
-    if file_.s3_url is None or file_.content is None:
-        if settings.ASYNC_FILE_PROCESSING:
-            pipeline(
-                [
-                    backup_file.message(file_.pk),
-                    content_from_file.message_with_options(
-                        pipe_ignore=True, args=(file_.pk,)
-                    ),
-                ]
-            ).run()
-        else:
-            backup_file_url = backup_file(file_.pk)
-            if backup_file_url:
-                content_from_file(file_.pk)

--- a/datasets/signals.py
+++ b/datasets/signals.py
@@ -1,0 +1,26 @@
+from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from dramatiq import pipeline
+
+from .models import File
+
+
+@receiver(post_save, sender=File)
+def backup_and_extract_content(sender, instance, **kwargs):
+    from .tasks import backup_file, content_from_file
+
+    if instance.s3_url is None or instance.content is None:
+        if settings.ASYNC_FILE_PROCESSING:
+            pipeline(
+                [
+                    backup_file.message(instance.pk),
+                    content_from_file.message_with_options(
+                        pipe_ignore=True, args=(instance.pk,)
+                    ),
+                ]
+            ).run()
+        else:
+            backup_file_url = backup_file(instance.pk)
+            if backup_file_url:
+                content_from_file(instance.pk)

--- a/datasets/tests/conftest.py
+++ b/datasets/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 
 @pytest.fixture
-def mock_save_file(mocker):
-    parser_mock = mocker.patch("datasets.management.commands._file.pipeline")
-    return parser_mock
+def mock_save_file(mocker, settings):
+    settings.ASYNC_FILE_PROCESSING = True
+    pipeline_mock = mocker.patch("datasets.signals.pipeline")
+    return pipeline_mock

--- a/datasets/tests/test_signals.py
+++ b/datasets/tests/test_signals.py
@@ -1,0 +1,24 @@
+import pytest
+from model_bakery import baker
+
+
+@pytest.mark.django_db
+def test_backup_and_extract_content_when_file_is_saved_with_async(mock_save_file):
+    baker.make("datasets.File", s3_url=None, content=None)
+
+    assert mock_save_file.called is True
+    assert mock_save_file.call_args_list[0][0][0][0].actor_name == "backup_file"
+    assert mock_save_file.call_args_list[0][0][0][1].actor_name == "content_from_file"
+
+
+@pytest.mark.django_db
+def test_backup_and_extract_content_when_file_is_saved_without_async(mocker, settings):
+    settings.ASYNC_FILE_PROCESSING = False
+    backup_file_mock = mocker.patch("datasets.tasks.backup_file")
+    backup_file_mock.return_value = "https://www.fake-url.com/file.pdf"
+    content_from_file_mock = mocker.patch("datasets.tasks.content_from_file")
+
+    baker.make("datasets.File", s3_url=None, content=None)
+
+    assert backup_file_mock.called is True
+    assert content_from_file_mock.called is True


### PR DESCRIPTION
Isso era feito apenas quando tínhamos arquivos salvos a partir da raspagem de dados. Agora, para todo e qualquer arquivo salvo no banco verificamos se já tem backup e se o conteúdo já foi extraído.

Close #220.