### PR TITLE
fix #239 : Garante datetime aware no scraper

### DIFF
--- a/datasets/management/commands/_citycouncil.py
+++ b/datasets/management/commands/_citycouncil.py
@@ -14,7 +14,7 @@ def save_agenda(item):
         title=item["title"],
         event_type=item["event_type"],
         crawled_from=item["crawled_from"],
-        defaults={"crawled_at": item["crawled_at"], "details": item["details"],},
+        defaults={"crawled_at": item["crawled_at"], "details": item["details"]},
     )
     return agenda
 

--- a/datasets/management/commands/_citycouncil.py
+++ b/datasets/management/commands/_citycouncil.py
@@ -6,7 +6,6 @@ from datasets.models import (
     CityCouncilMinute,
 )
 from django.contrib.admin.options import get_content_type_for_model
-from django.utils.timezone import make_aware
 
 
 def save_agenda(item):
@@ -15,10 +14,7 @@ def save_agenda(item):
         title=item["title"],
         event_type=item["event_type"],
         crawled_from=item["crawled_from"],
-        defaults={
-            "crawled_at": make_aware(item["crawled_at"]),
-            "details": item["details"],
-        },
+        defaults={"crawled_at": item["crawled_at"], "details": item["details"],},
     )
     return agenda
 
@@ -28,7 +24,7 @@ def save_attendance_list(item):
         date=item["date"],
         council_member=item["council_member"],
         defaults={
-            "crawled_at": make_aware(item["crawled_at"]),
+            "crawled_at": item["crawled_at"],
             "crawled_from": item["crawled_from"],
             "description": item["description"],
             "status": item.get("status"),
@@ -56,7 +52,7 @@ def save_expense(item):
         subgroup=item["subgroup"],
         group=item["group"],
         defaults={
-            "crawled_at": make_aware(item["crawled_at"]),
+            "crawled_at": item["crawled_at"],
             "crawled_from": item["crawled_from"],
         },
     )
@@ -70,7 +66,7 @@ def save_minute(item):
         defaults={
             "title": item["title"],
             "event_type": item["event_type"],
-            "crawled_at": make_aware(item["crawled_at"]),
+            "crawled_at": item["crawled_at"],
         },
     )
     if created and item.get("files"):

--- a/datasets/management/commands/_cityhall.py
+++ b/datasets/management/commands/_cityhall.py
@@ -1,6 +1,5 @@
 from datasets.models import CityHallBid, CityHallBidEvent
 from django.contrib.admin.options import get_content_type_for_model
-from django.utils.timezone import make_aware
 
 from ._file import save_file
 
@@ -12,7 +11,7 @@ def save_bid(item):
         codes=item["codes"],
         defaults={
             "crawled_from": item["crawled_from"],
-            "crawled_at": make_aware(item["crawled_at"]),
+            "crawled_at": item["crawled_at"],
             "description": item["description"],
             "modality": item["modality"],
         },
@@ -30,7 +29,7 @@ def save_bid(item):
             bid=bid,
             published_at=event["published_at"],
             summary=event["event"],
-            defaults={"crawled_at": make_aware(item["crawled_at"])},
+            defaults={"crawled_at": item["crawled_at"]},
         )
         if created and event.get("url"):
             save_file(event.get("url"), content_type, event_obj.pk)

--- a/datasets/management/commands/_gazette.py
+++ b/datasets/management/commands/_gazette.py
@@ -3,7 +3,6 @@ from datetime import date
 
 from datasets.models import Gazette, GazetteEvent
 from django.contrib.admin.options import get_content_type_for_model
-from django.utils.timezone import make_aware
 
 from ._file import save_file
 
@@ -15,7 +14,7 @@ def save_gazette(item):
         power=item["power"],
         year_and_edition=item["year_and_edition"],
         defaults={
-            "crawled_at": make_aware(item["crawled_at"]),
+            "crawled_at": item["crawled_at"],
             "crawled_from": item["crawled_from"],
         },
     )
@@ -32,7 +31,7 @@ def save_gazette(item):
             secretariat=event["secretariat"],
             crawled_from=item["crawled_from"],
             summary=event["summary"],
-            defaults={"crawled_at": make_aware(item["crawled_at"])},
+            defaults={"crawled_at": item["crawled_at"]},
         )
     return gazette
 
@@ -59,7 +58,7 @@ def save_legacy_gazette(item):
         power="executivo",
         crawled_from=item["crawled_from"],
         is_legacy=True,
-        defaults={"crawled_at": make_aware(item["crawled_at"]), "notes": notes},
+        defaults={"crawled_at": item["crawled_at"], "notes": notes},
     )
 
     if created and item.get("files"):
@@ -73,7 +72,7 @@ def save_legacy_gazette(item):
         crawled_from=item["crawled_from"],
         summary=item["details"],
         published_on=item["published_on"],
-        crawled_at=make_aware(item["crawled_at"]),
+        crawled_at=item["crawled_at"],
     )
     return gazette
 

--- a/datasets/tests/management/commands/test_citycouncil.py
+++ b/datasets/tests/management/commands/test_citycouncil.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
 
 import pytest
+from django.utils.timezone import make_aware
+
 from datasets.management.commands._citycouncil import (
     save_agenda,
     save_attendance_list,
@@ -12,7 +14,7 @@ from datasets.management.commands._citycouncil import (
 class TestSaveAgenda:
     def test_save_gazette(self):
         item = {
-            "crawled_at": datetime(2020, 3, 21, 7, 15, 17, 908831),
+            "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 908831)),
             "crawled_from": "https://www.feiradesantana.ba.leg.br/agenda",
             "date": date(2019, 8, 29),
             "details": "- Especial , dia 29 (quinta-feira), às 09 horas,"
@@ -33,12 +35,12 @@ class TestSaveAgenda:
         assert agenda.details == item["details"]
         assert agenda.event_type == item["event_type"]
         assert agenda.title == item["title"]
-        assert agenda.crawled_at.replace(tzinfo=None) == item["crawled_at"]
+        assert agenda.crawled_at == item["crawled_at"]
         assert agenda.crawled_from == item["crawled_from"]
 
     def test_handle_with_changed_agenda(self):
         item = {
-            "crawled_at": datetime(2020, 3, 21, 7, 15, 17, 908831),
+            "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 908831)),
             "crawled_from": "https://www.feiradesantana.ba.leg.br/agenda",
             "date": date(2019, 8, 29),
             "details": "- Especial , dia 29 (quinta-feira), às 09 horas,"
@@ -56,7 +58,7 @@ class TestSaveAgenda:
 
         agenda = save_agenda(item)
         item["details"] = "Festa na cidade bla bla bla"
-        item["crawled_at"] = datetime(2020, 3, 22, 7, 15, 17, 908831)
+        item["crawled_at"] = make_aware(datetime(2020, 3, 22, 7, 15, 17, 908831))
 
         updated_agenda = save_agenda(item)
 
@@ -73,7 +75,7 @@ class TestSaveAttendanceList:
             "description": "Abertura da 1ª etapa do 4º período da 18ª legislatura",
             "council_member": "Roberto Luis da Silva Tourinho",
             "status": "presente",
-            "crawled_at": datetime(2020, 3, 21, 7, 15, 17, 276019),
+            "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 276019)),
             "crawled_from": "https://www.feiradesantana.ba.leg.br/lista/7/03-02-2020",
         }
 
@@ -82,7 +84,7 @@ class TestSaveAttendanceList:
         assert attendance.description == item["description"]
         assert attendance.council_member == item["council_member"]
         assert attendance.status == item["status"]
-        assert attendance.crawled_at.replace(tzinfo=None) == item["crawled_at"]
+        assert attendance.crawled_at == item["crawled_at"]
         assert attendance.crawled_from == item["crawled_from"]
 
     def test_handle_with_changed_attendance_list(self):
@@ -91,13 +93,13 @@ class TestSaveAttendanceList:
             "description": "Abertura da 1ª etapa do 4º período da 18ª legislatura",
             "council_member": "Roberto Luis da Silva Tourinho",
             "status": "ausente",
-            "crawled_at": datetime(2020, 3, 21, 7, 15, 17, 276019),
+            "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 276019)),
             "crawled_from": "https://www.feiradesantana.ba.leg.br/lista/7/03-02-2020",
         }
 
         attendance = save_attendance_list(item)
         item["status"] = "falta_justificada"
-        item["crawled_at"] = datetime(2020, 3, 22, 7, 15, 17, 908831)
+        item["crawled_at"] = make_aware(datetime(2020, 3, 22, 7, 15, 17, 908831))
 
         updated_attendance = save_attendance_list(item)
 
@@ -113,7 +115,7 @@ class TestSaveAttendanceList:
 class TestSaveMinute:
     def test_save_minute(self, mock_save_file):
         item = {
-            "crawled_at": datetime(2020, 4, 30, 18, 18, 56, 173788),
+            "crawled_at": make_aware(datetime(2020, 4, 30, 18, 18, 56, 173788)),
             "crawled_from": "https://www.feiradesantana.ba.leg.br/atas?"
             "mes=9&ano=2018&Acessar=OK",
             "date": date(2018, 9, 11),

--- a/datasets/tests/management/commands/test_cityhall.py
+++ b/datasets/tests/management/commands/test_cityhall.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
 import pytest
+from django.utils.timezone import make_aware
+
 from datasets.management.commands._cityhall import save_bid
 
 
@@ -8,9 +10,9 @@ from datasets.management.commands._cityhall import save_bid
 class TestSaveBid:
     def test_save_bid(self, mock_save_file):
         item = {
-            "crawled_at": datetime(2020, 3, 21, 7, 15, 17, 908831),
+            "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 908831)),
             "crawled_from": "http://www.feiradesantana.ba.gov.br/servicos.asp",
-            "session_at": datetime(2018, 4, 17, 8, 30, 0),
+            "session_at": make_aware(datetime(2018, 4, 17, 8, 30, 0)),
             "public_agency": "PMFS",
             "month": 4,
             "year": 2018,
@@ -43,9 +45,9 @@ class TestSaveBid:
     def test_save_history(self, mock_save_file):
         item = {
             "public_agency": "PMFS",
-            "crawled_at": datetime(2020, 4, 4, 14, 29, 49, 261985),
+            "crawled_at": make_aware(datetime(2020, 4, 4, 14, 29, 49, 261985)),
             "crawled_from": "http://www.feiradesantana.ba.gov.br/servicos.asp",
-            "session_at": datetime(2019, 4, 5, 8, 30),
+            "session_at": make_aware(datetime(2019, 4, 5, 8, 30)),
             "description": (
                 "Contratação de empresa para prestação de serviços "
                 "profissionais de apoio administrativo em Unidades de Saúde da "
@@ -59,7 +61,7 @@ class TestSaveBid:
             "modality": "pregao_eletronico",
             "history": [
                 {
-                    "published_at": datetime(2018, 4, 17, 8, 30, 0),
+                    "published_at": make_aware(datetime(2018, 4, 17, 8, 30, 0)),
                     "event": "Resposta a pedido de esclarecimento",
                     "url": "http://www.feiradesantana.ba.gov.br/SMS.pdf",
                 }
@@ -76,9 +78,9 @@ class TestSaveBid:
     def test_handle_with_existent_event(self, mock_save_file):
         item = {
             "public_agency": "PMFS",
-            "crawled_at": datetime(2020, 4, 4, 14, 29, 49, 261985),
+            "crawled_at": make_aware(datetime(2020, 4, 4, 14, 29, 49, 261985)),
             "crawled_from": "http://www.feiradesantana.ba.gov.br/servicos.asp",
-            "session_at": datetime(2019, 4, 5, 8, 30),
+            "session_at": make_aware(datetime(2019, 4, 5, 8, 30)),
             "description": (
                 "Contratação de empresa para prestação de serviços "
                 "profissionais de apoio administrativo em Unidades de Saúde da "
@@ -92,7 +94,7 @@ class TestSaveBid:
             "modality": "pregao_eletronico",
             "history": [
                 {
-                    "published_at": datetime(2019, 4, 4, 16, 20, 0),
+                    "published_at": make_aware(datetime(2019, 4, 4, 16, 20, 0)),
                     "event": "Resposta a pedido de esclarecimento",
                     "url": "http://www.feiradesantana.ba.gov.br/SMS.pdf",
                 }
@@ -103,17 +105,17 @@ class TestSaveBid:
 
         item["history"] = [
             {
-                "published_at": datetime(2019, 4, 4, 16, 20, 0),
+                "published_at": make_aware(datetime(2019, 4, 4, 16, 20, 0)),
                 "event": "Resposta a pedido de esclarecimento",
                 "url": "http://www.feiradesantana.ba.gov.br/SMS.pdf",
             },
             {
-                "published_at": datetime(2019, 4, 4, 18, 20, 0),
+                "published_at": make_aware(datetime(2019, 4, 4, 18, 20, 0)),
                 "event": "Resposta a pedido de esclarecimento",
                 "url": "http://www.feiradesantana.ba.gov.br/SMS.pdf",
             },
             {
-                "published_at": datetime(2019, 4, 4, 16, 20, 0),
+                "published_at": make_aware(datetime(2019, 4, 4, 16, 20, 0)),
                 "event": "CORREÇÃO DE EDITAL",
                 "url": "http://www.feiradesantana.ba.gov.br/SMS.pdf",
             },
@@ -124,9 +126,9 @@ class TestSaveBid:
 
     def test_handle_with_updated_bid(self, mock_save_file):
         item = {
-            "crawled_at": datetime(2020, 3, 21, 7, 15, 17, 908831),
+            "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 908831)),
             "crawled_from": "http://www.feiradesantana.ba.gov.br/servicos.asp",
-            "session_at": datetime(2018, 4, 17, 8, 30, 0),
+            "session_at": make_aware(datetime(2018, 4, 17, 8, 30, 0)),
             "public_agency": "PMFS",
             "month": 4,
             "year": 2018,
@@ -160,9 +162,9 @@ class TestSaveBid:
 
     def test_create_different_bids_for_different_agency_modality(self, mock_save_file):
         item = {
-            "crawled_at": datetime(2020, 3, 21, 7, 15, 17, 908831),
+            "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 908831)),
             "crawled_from": "http://www.feiradesantana.ba.gov.br/servicos.asp",
-            "session_at": datetime(2018, 4, 17, 8, 30, 0),
+            "session_at": make_aware(datetime(2018, 4, 17, 8, 30, 0)),
             "public_agency": "PMFS",
             "month": 4,
             "year": 2018,

--- a/datasets/tests/management/commands/test_gazette.py
+++ b/datasets/tests/management/commands/test_gazette.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
 
 import pytest
+from django.utils.timezone import make_aware
+
 from datasets.management.commands._gazette import (
     _extract_date,
     save_gazette,
@@ -12,10 +14,10 @@ from datasets.management.commands._gazette import (
 class TestSaveGazette:
     def test_save_gazette(self, mock_save_file):
         item = {
-            "date": datetime(2019, 11, 5),
+            "date": date(2019, 11, 5),
             "power": "executivo",
             "year_and_edition": "Ano V - Edi\u00e7\u00e3o N\u00ba 1131",
-            "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+            "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
             "crawled_from": "http://www.diariooficial.br/st=1&publ=1&edicao=1131",
             "events": [
                 {
@@ -31,7 +33,7 @@ class TestSaveGazette:
         assert gazette.date == item["date"]
         assert gazette.power == item["power"]
         assert gazette.year_and_edition == item["year_and_edition"]
-        assert gazette.crawled_at.replace(tzinfo=None) == item["crawled_at"]
+        assert gazette.crawled_at == item["crawled_at"]
         assert gazette.crawled_from == item["crawled_from"]
         assert gazette.files.count() == 1
 
@@ -42,10 +44,10 @@ class TestSaveGazette:
 
     def test_save_different_events_to_same_gazette(self, mock_save_file):
         item = {
-            "date": datetime(2019, 11, 5),
+            "date": date(2019, 11, 5),
             "power": "executivo",
             "year_and_edition": "Ano V - Edi\u00e7\u00e3o N\u00ba 1131",
-            "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+            "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
             "crawled_from": "http://www.diariooficial.br/st=1&edicao=1131",
             "events": [
                 {
@@ -72,9 +74,9 @@ class TestSaveLegacyGazette:
         legacy_item = {
             "title": "DECRETO Nº 9.416, DE 26 DE NOVEMBRO DE 2014.",
             "published_on": "Folha do Estado",
-            "date": datetime(2014, 11, 27),
+            "date": make_aware(datetime(2014, 11, 27)),
             "details": "ABRE CRÉDITO SUPLEMENTAR AO ORÇAMENTO DO MUNICÍPIO...",
-            "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+            "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
             "crawled_from": "http://www.diariooficial.br/st=1&publicacao=1",
         }
 
@@ -84,7 +86,7 @@ class TestSaveLegacyGazette:
         assert gazette.power == "executivo"
         assert gazette.year_and_edition == ""
         assert gazette.is_legacy is True
-        assert gazette.crawled_at.replace(tzinfo=None) == legacy_item["crawled_at"]
+        assert gazette.crawled_at == legacy_item["crawled_at"]
         assert gazette.crawled_from == legacy_item["crawled_from"]
         assert gazette.events.count() == 1
 
@@ -99,28 +101,28 @@ class TestSaveLegacyGazette:
             {
                 "title": "DECRETO Nº 9.416, DE 26 DE NOVEMBRO DE 2014.",
                 "published_on": "Folha do Estado",
-                "date": datetime(2014, 11, 27),
+                "date": date(2014, 11, 27),
                 "details": "ABRE CRÉDITO SUPLEMENTAR AO ORÇAMENTO DO MUNICÍPIO...",
                 "files": ["http://www.feiradesantana.ba.gov.br/leis/Deno20149416.pdf"],
-                "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+                "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
                 "crawled_from": "http://www.diariooficial.br/st=1&&edicao=1131",
             },
             {
                 "title": "DECRETO Nº 9.415, DE 26 DE NOVEMBRO DE 2014.",
                 "published_on": "Folha do Estado",
-                "date": datetime(2014, 11, 27),
+                "date": date(2014, 11, 27),
                 "details": "ALTERA O QUADRO DE DETALHAMENTO DE DESPESA...",
                 "files": ["http://www.diariooficial.feira.ba.gov.br/d.pdf"],
-                "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+                "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
                 "crawled_from": "http://www.diariooficial.br/st=1&&edicao=1131",
             },
             {
                 "title": "DECRETO Nº 9.414, DE 26 DE NOVEMBRO DE 2014.",
                 "published_on": "Folha do Estado",
-                "date": datetime(2014, 11, 27),
+                "date": date(2014, 11, 27),
                 "details": "ALTERA O QUADRO DE DETALHAMENTO DE DESPESA...",
                 "files": ["http://www.diariooficial.feira.ba.gov.br/d.pdf"],
-                "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+                "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
                 "crawled_from": "http://www.diariooficial.br/st=1&&edicao=1131",
             },
         ]
@@ -138,25 +140,25 @@ class TestSaveLegacyGazette:
                 "date": None,
                 "details": "ABRE CRÉDITO SUPLEMENTAR AO ORÇAMENTO DO MUNICÍPIO...",
                 "files": ["http://www.diariooficial.feira.ba.gov.br/d.pdf"],
-                "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+                "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
                 "crawled_from": "http://www.diariooficial.br/?st=1&edicao=1130",
             },
             {
                 "title": "DECRETO Nº 9.415, DE 26 DE NOVEMBRO DE 2014.",
                 "published_on": "Folha do Estado",
-                "date": datetime(2014, 11, 27),
+                "date": date(2014, 11, 27),
                 "details": "ALTERA O QUADRO DE DETALHAMENTO DE DESPESA...",
                 "files": ["http://www.diariooficial.feira.ba.gov.br/d.pdf"],
-                "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+                "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
                 "crawled_from": "http://www.diariooficial.br/?&edicao=1131",
             },
             {
                 "title": "DECRETO Nº 9.414, DE 26 DE NOVEMBRO DE 2014.",
                 "published_on": "Folha do Estado",
-                "date": datetime(2014, 11, 26),
+                "date": date(2014, 11, 26),
                 "details": "ALTERA O QUADRO DE DETALHAMENTO DE DESPESA...",
                 "files": ["http://www.diariooficial.feira.ba.gov.br/d.pdf"],
-                "crawled_at": datetime(2019, 11, 6, 10, 11, 19),
+                "crawled_at": make_aware(datetime(2019, 11, 6, 10, 11, 19)),
                 "crawled_from": "http://www.diariooficial.br/?&edicao=1131",
             },
         ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ sentry-dramatiq==0.3.2
 sentry-sdk==0.19.1
 spidermon==1.14.0
 tika==1.24
+tzlocal==2.1
 whitenoise==5.2.0
 xlrd==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@ sentry-dramatiq==0.3.2
 sentry-sdk==0.19.1
 spidermon==1.14.0
 tika==1.24
-tzlocal==2.1
 whitenoise==5.2.0
 xlrd==1.2.0

--- a/scraper/spiders/citycouncil.py
+++ b/scraper/spiders/citycouncil.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date
 
 import scrapy
 from datasets.parsers import from_str_to_date
@@ -9,7 +9,7 @@ from scraper.items import (
 )
 
 from . import BaseSpider
-from .utils import extract_date, months_and_years
+from .utils import datetime_now_aware, extract_date, months_and_years
 
 
 class AgendaSpider(BaseSpider):
@@ -63,7 +63,7 @@ class AgendaSpider(BaseSpider):
             ]
             event_date = from_str_to_date(event_date)
             yield CityCouncilAgendaItem(
-                crawled_at=datetime.now(),
+                crawled_at=datetime_now_aware(),
                 crawled_from=response.url,
                 date=event_date,
                 details=" ".join(events),
@@ -89,7 +89,7 @@ class AttendanceListSpider(BaseSpider):
         return status_labels.get(status.upper().strip())
 
     def start_requests(self):
-        today = datetime.now().date()
+        today = datetime_now_aware().date()
         self.logger.info(f"Data inicial: {self.start_date}")
 
         for month, year in months_and_years(self.start_date, today):
@@ -115,7 +115,7 @@ class AttendanceListSpider(BaseSpider):
 
         for council_member, status in zip(council_members, status):
             yield CityCouncilAttendanceListItem(
-                crawled_at=datetime.now(),
+                crawled_at=datetime_now_aware(),
                 crawled_from=response.url,
                 date=extract_date(title),
                 description=description.strip() if description else "",
@@ -147,7 +147,7 @@ class MinuteSpider(BaseSpider):
 
     def start_requests(self):
         self.logger.info(f"Data inicial: {self.start_date}")
-        today = datetime.now().date()
+        today = datetime_now_aware().date()
 
         for month, year in months_and_years(self.start_date, today):
             url = (
@@ -164,7 +164,7 @@ class MinuteSpider(BaseSpider):
         for event_date, title, file_url in zip(dates, event_titles, file_urls):
             event_date = from_str_to_date(event_date)
             yield CityCouncilMinuteItem(
-                crawled_at=datetime.now(),
+                crawled_at=datetime_now_aware(),
                 crawled_from=response.url,
                 date=event_date,
                 title=title.strip(),

--- a/scraper/spiders/citycouncil.py
+++ b/scraper/spiders/citycouncil.py
@@ -9,7 +9,7 @@ from scraper.items import (
 )
 
 from . import BaseSpider
-from .utils import datetime_now_aware, extract_date, months_and_years
+from .utils import datetime_utcnow_aware, extract_date, months_and_years
 
 
 class AgendaSpider(BaseSpider):
@@ -63,7 +63,7 @@ class AgendaSpider(BaseSpider):
             ]
             event_date = from_str_to_date(event_date)
             yield CityCouncilAgendaItem(
-                crawled_at=datetime_now_aware(),
+                crawled_at=datetime_utcnow_aware(),
                 crawled_from=response.url,
                 date=event_date,
                 details=" ".join(events),
@@ -89,7 +89,7 @@ class AttendanceListSpider(BaseSpider):
         return status_labels.get(status.upper().strip())
 
     def start_requests(self):
-        today = datetime_now_aware().date()
+        today = datetime_utcnow_aware().date()
         self.logger.info(f"Data inicial: {self.start_date}")
 
         for month, year in months_and_years(self.start_date, today):
@@ -115,7 +115,7 @@ class AttendanceListSpider(BaseSpider):
 
         for council_member, status in zip(council_members, status):
             yield CityCouncilAttendanceListItem(
-                crawled_at=datetime_now_aware(),
+                crawled_at=datetime_utcnow_aware(),
                 crawled_from=response.url,
                 date=extract_date(title),
                 description=description.strip() if description else "",
@@ -147,7 +147,7 @@ class MinuteSpider(BaseSpider):
 
     def start_requests(self):
         self.logger.info(f"Data inicial: {self.start_date}")
-        today = datetime_now_aware().date()
+        today = datetime_utcnow_aware().date()
 
         for month, year in months_and_years(self.start_date, today):
             url = (
@@ -164,7 +164,7 @@ class MinuteSpider(BaseSpider):
         for event_date, title, file_url in zip(dates, event_titles, file_urls):
             event_date = from_str_to_date(event_date)
             yield CityCouncilMinuteItem(
-                crawled_at=datetime_now_aware(),
+                crawled_at=datetime_utcnow_aware(),
                 crawled_from=response.url,
                 date=event_date,
                 title=title.strip(),

--- a/scraper/spiders/cityhall.py
+++ b/scraper/spiders/cityhall.py
@@ -7,7 +7,7 @@ from scraper.items import CityHallBidItem, CityHallContractItem, CityHallPayment
 
 from . import BaseSpider
 from .utils import (
-    datetime_now_aware,
+    datetime_utcnow_aware,
     extract_param,
     identify_contract_id,
     is_url,
@@ -101,7 +101,7 @@ class BidsSpider(BaseSpider):
             month, year = match.group(2).split("-")
 
             item = CityHallBidItem(
-                crawled_at=datetime_now_aware(),
+                crawled_at=datetime_utcnow_aware(),
                 crawled_from=response.url,
                 public_agency=match.group(1).upper(),
                 month=int(month),
@@ -197,7 +197,7 @@ class ContractsSpider(BaseSpider):
     def start_requests(self):
         start_date = self.start_date
         self.logger.info(f"Data inicial: {start_date}")
-        today = datetime_now_aware().date()
+        today = datetime_utcnow_aware().date()
 
         while start_date < today:
             formatted_date = start_date.strftime("%d/%m/%Y")
@@ -258,7 +258,7 @@ class ContractsSpider(BaseSpider):
                 contractor_name=contractor_name,
                 value=details[2],
                 ends_at=details[3],
-                crawled_at=datetime_now_aware(),
+                crawled_at=datetime_utcnow_aware(),
                 crawled_from=response.url,
             )
             if document_url:
@@ -304,7 +304,7 @@ class PaymentsSpider(BaseSpider):
     def start_requests(self):
         start_date = self.start_date
         self.logger.info(f"Data inicial: {start_date}")
-        today = datetime_now_aware().date()
+        today = datetime_utcnow_aware().date()
 
         while start_date < today:
             formatted_date = start_date.strftime("%d/%m/%Y")
@@ -353,7 +353,7 @@ class PaymentsSpider(BaseSpider):
                 phase=headline[1],
                 company_or_person=headline[2],
                 value=headline[3],
-                crawled_at=datetime_now_aware(),
+                crawled_at=datetime_utcnow_aware(),
                 crawled_from=response.url,
             )
             details = [
@@ -448,7 +448,7 @@ class COVID19ExpensesSpider(BaseSpider):
                 phase=headline[1],
                 company_or_person=headline[2],
                 value=headline[3],
-                crawled_at=datetime_now_aware(),
+                crawled_at=datetime_utcnow_aware(),
                 crawled_from=self.source,
             )
             details = [

--- a/scraper/spiders/cityhall.py
+++ b/scraper/spiders/cityhall.py
@@ -1,12 +1,18 @@
 import re
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 import scrapy
 from datasets.parsers import from_str_to_datetime
 from scraper.items import CityHallBidItem, CityHallContractItem, CityHallPaymentsItem
 
 from . import BaseSpider
-from .utils import extract_param, identify_contract_id, is_url, strip_accents
+from .utils import (
+    datetime_now_aware,
+    extract_param,
+    identify_contract_id,
+    is_url,
+    strip_accents,
+)
 
 
 class BidsSpider(BaseSpider):
@@ -95,7 +101,7 @@ class BidsSpider(BaseSpider):
             month, year = match.group(2).split("-")
 
             item = CityHallBidItem(
-                crawled_at=datetime.now(),
+                crawled_at=datetime_now_aware(),
                 crawled_from=response.url,
                 public_agency=match.group(1).upper(),
                 month=int(month),
@@ -191,7 +197,7 @@ class ContractsSpider(BaseSpider):
     def start_requests(self):
         start_date = self.start_date
         self.logger.info(f"Data inicial: {start_date}")
-        today = datetime.now().date()
+        today = datetime_now_aware().date()
 
         while start_date < today:
             formatted_date = start_date.strftime("%d/%m/%Y")
@@ -252,7 +258,7 @@ class ContractsSpider(BaseSpider):
                 contractor_name=contractor_name,
                 value=details[2],
                 ends_at=details[3],
-                crawled_at=datetime.now(),
+                crawled_at=datetime_now_aware(),
                 crawled_from=response.url,
             )
             if document_url:
@@ -298,7 +304,7 @@ class PaymentsSpider(BaseSpider):
     def start_requests(self):
         start_date = self.start_date
         self.logger.info(f"Data inicial: {start_date}")
-        today = datetime.now().date()
+        today = datetime_now_aware().date()
 
         while start_date < today:
             formatted_date = start_date.strftime("%d/%m/%Y")
@@ -347,7 +353,7 @@ class PaymentsSpider(BaseSpider):
                 phase=headline[1],
                 company_or_person=headline[2],
                 value=headline[3],
-                crawled_at=datetime.now(),
+                crawled_at=datetime_now_aware(),
                 crawled_from=response.url,
             )
             details = [
@@ -442,7 +448,7 @@ class COVID19ExpensesSpider(BaseSpider):
                 phase=headline[1],
                 company_or_person=headline[2],
                 value=headline[3],
-                crawled_at=datetime.now(),
+                crawled_at=datetime_now_aware(),
                 crawled_from=self.source,
             )
             details = [

--- a/scraper/spiders/gazette.py
+++ b/scraper/spiders/gazette.py
@@ -1,11 +1,11 @@
-from datetime import date, datetime
+from datetime import date
 
 from datasets.parsers import from_str_to_date
 from scraper.items import GazetteItem, LegacyGazetteItem
 from scrapy import Request
 
 from . import BaseSpider
-from .utils import replace_query_param
+from .utils import datetime_now_aware, replace_query_param
 
 
 class LegacyGazetteSpider(BaseSpider):
@@ -35,7 +35,7 @@ class LegacyGazetteSpider(BaseSpider):
                     date=from_str_to_date(event["date"]),
                     details=url["details"],
                     files=[url["url"]],
-                    crawled_at=datetime.now(),
+                    crawled_at=datetime_now_aware(),
                     crawled_from=response.url,
                 )
 
@@ -187,7 +187,7 @@ class ExecutiveAndLegislativeGazetteSpider(BaseSpider):
                     power=gazette["power"],
                     year_and_edition=gazette["year_and_edition"],
                     events=gazette["events"],
-                    crawled_at=datetime.now(),
+                    crawled_at=datetime_now_aware(),
                     crawled_from=response.url,
                 )
                 yield Request(

--- a/scraper/spiders/gazette.py
+++ b/scraper/spiders/gazette.py
@@ -5,7 +5,7 @@ from scraper.items import GazetteItem, LegacyGazetteItem
 from scrapy import Request
 
 from . import BaseSpider
-from .utils import datetime_now_aware, replace_query_param
+from .utils import datetime_utcnow_aware, replace_query_param
 
 
 class LegacyGazetteSpider(BaseSpider):
@@ -35,7 +35,7 @@ class LegacyGazetteSpider(BaseSpider):
                     date=from_str_to_date(event["date"]),
                     details=url["details"],
                     files=[url["url"]],
-                    crawled_at=datetime_now_aware(),
+                    crawled_at=datetime_utcnow_aware(),
                     crawled_from=response.url,
                 )
 
@@ -187,7 +187,7 @@ class ExecutiveAndLegislativeGazetteSpider(BaseSpider):
                     power=gazette["power"],
                     year_and_edition=gazette["year_and_edition"],
                     events=gazette["events"],
-                    crawled_at=datetime_now_aware(),
+                    crawled_at=datetime_utcnow_aware(),
                     crawled_from=response.url,
                 )
                 yield Request(

--- a/scraper/spiders/gazette.py
+++ b/scraper/spiders/gazette.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 
 from datasets.parsers import from_str_to_date
 from scraper.items import GazetteItem, LegacyGazetteItem

--- a/scraper/spiders/utils.py
+++ b/scraper/spiders/utils.py
@@ -1,9 +1,10 @@
 import logging
 import re
 import unicodedata
-import tzlocal
-from datetime import datetime
+
+from datetime import datetime, timezone
 from urllib.parse import parse_qs, urlparse
+
 
 from datasets.parsers import from_str_to_date
 
@@ -111,6 +112,6 @@ def strip_accents(string):
     )
 
 
-def datetime_now_aware() -> datetime:
-    """Create a datetime now aware using local timezone."""
-    return datetime.now(tz=tzlocal.get_localzone())
+def datetime_utcnow_aware() -> datetime:
+    """Data e hora UTC com informação de timezone."""
+    return datetime.utcnow().replace(tzinfo=timezone.utc)

--- a/scraper/spiders/utils.py
+++ b/scraper/spiders/utils.py
@@ -1,6 +1,8 @@
 import logging
 import re
 import unicodedata
+import tzlocal
+from datetime import datetime
 from urllib.parse import parse_qs, urlparse
 
 from datasets.parsers import from_str_to_date
@@ -107,3 +109,8 @@ def strip_accents(string):
         for char in unicodedata.normalize("NFD", string)
         if unicodedata.category(char) != "Mn"
     )
+
+
+def datetime_now_aware() -> datetime:
+    """Create a datetime now aware using local timezone."""
+    return datetime.now(tz=tzlocal.get_localzone())


### PR DESCRIPTION
Scraper passa a usar datetime aware no campo `crawled_at`.

O TIMEZONE atual sera detectado usando o pacote tzlocal.
Isso garante que o timezone to sistema executando o scrap sera aplicado.
Nesse caso, as fucoes que salvam os items definidas em datasets/management
nao precisam mais usar `django.utils.timezone.make_aware`.

Assim, assume-se que todas as entradas de dados sao datetime aware.

Nas fixtures usadas nos tests foi usado django.utils.timezone.make_aware
para garantir que todos os campos datetime sao datetime aware.

Com isso os warnings relativos falta de tzinfo nos campos datetime
durante os testes foram tambem solucionados.