### PR TITLE
fix #226 : Adiciona DRF e implementa endpoint de health check

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1,0 +1,10 @@
+from api.views import HealthCheckView
+from django.urls import include, path
+from rest_framework import routers
+
+router = routers.DefaultRouter()
+
+urlpatterns = [
+    path("datasets/", include(router.urls)),
+    path("", HealthCheckView.as_view()),
+]

--- a/api/tests/test_health_check.py
+++ b/api/tests/test_health_check.py
@@ -1,0 +1,14 @@
+from rest_framework.test import APITestCase
+
+
+class HealthCheckTests(APITestCase):
+    def setUp(self):
+        self.response = self.client.get("/web-api/", HTTP_HOST="localhost:8000")
+        self.content = self.response.json()
+
+    def test_status_code_health_check(self):
+        self.assertEquals(self.response.status_code, 200)
+
+    def test_content_health_check(self):
+        self.assertEquals(["status", "time"], list(self.content.keys()))
+        self.assertEquals(self.content.get("status"), "available")

--- a/api/views.py
+++ b/api/views.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class HealthCheckView(APIView):
+    def get(self, request):
+        return Response({"status": "available", "time": datetime.now()})

--- a/core/settings.py
+++ b/core/settings.py
@@ -35,6 +35,7 @@ class Common(Configuration):
         "django.contrib.messages",
         "django.contrib.staticfiles",
         "datasets.apps.DatasetsConfig",
+        "rest_framework",
         "simple_history",
     ]
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("home.urls")),
     path("painel/", public_admin.urls),
+    path("web-api/", include("api.routes")),
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ django==3.1.2
 django-configurations==2.2
 django-public-admin==0.0.5
 django-simple-history==2.12.0
+djangorestframework==3.12.2
 dramatiq[rabbitmq,watch]==1.9.0
 gunicorn==20.0.4
 jinja2==2.11.2


### PR DESCRIPTION
Cria a estrutura inicial da API no projeto

Adiciona o django rest framework, na versão mais atua, como dependência do projeto.
Foi criada um diretório `api/` na raiz do projeto e todo código referente a API deve ficar dentro desse diretório.
O endereço base escolhido para a API foi `web-api`.
O retorno do endpoint de _health check_ é simplesmente informando o status da API e a data/hora que a requisição foi feita.