### PR TITLE
Faz o download do Tika durante o release

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -7,4 +7,7 @@ PYTHON=$(which python3)
 echo "Running migrations"
 ${PYTHON} manage.py migrate --no-input
 
+echo "Downloading Apache Tika"
+wget https://www.apache.org/dyn/closer.cgi/tika/tika-server-1.25.jar -O tika-server.jar
+
 echo "Done!"


### PR DESCRIPTION
Até agora confiamos na biblioteca [python-tika](https://github.com/chrismattmann/tika-python) para gerenciar o download do jar que faz a extração do conteúdo dos arquivos. Já faz um tempo que o download vem falhando, deixando alguns documentos sem conteúdo. Nesse PR adiciono o download do jar durante o release. A variável `TIKA_SERVER_JAR` precisa ser configurada para apontar o caminho do jar para a biblioteca.