### PR TITLE
Adiciona paginação a API

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -20,7 +20,7 @@ class TestCityCouncilAgendaView:
 
         assert response.status_code == HTTPStatus.OK
 
-        data = response.json()
+        data = response.json()["results"]
         assert data[0]["date"] == agenda.date.strftime("%Y-%m-%d")
         assert data[0]["details"] == agenda.details
         assert data[0]["event_type"] == agenda.event_type
@@ -56,7 +56,7 @@ class TestCityCouncilAgendaView:
         response = api_client_authenticated.get(self.url, data=data)
 
         assert response.status_code == HTTPStatus.OK
-        assert len(response.json()) == quantity_expected
+        assert len(response.json()["results"]) == quantity_expected
 
     def test_filter_date_when_is_passing_wrong_format(self, api_client_authenticated):
         baker.make_recipe("datasets.CityCouncilAgenda")

--- a/core/settings.py
+++ b/core/settings.py
@@ -121,6 +121,8 @@ class Common(Configuration):
             "rest_framework.authentication.SessionAuthentication",
             "rest_framework_simplejwt.authentication.JWTAuthentication",
         ),
+        "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+        "PAGE_SIZE": 50,
     }
 
     ACCESS_TOKEN_LIFETIME_IN_MINUTES = int(


### PR DESCRIPTION
Por padrão serão exibidos 50 itens por página.