### PR TITLE
Endpoint para diários oficiais (#227)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ boto3==1.17.17
 dj-database-url==0.5.0
 django==3.1.7
 django-configurations==2.2
+django-filter==2.4.0
 django-public-admin==0.0.5
 django-simple-history==2.12.0
 djangorestframework==3.12.2

--- a/web/api/filters.py
+++ b/web/api/filters.py
@@ -1,0 +1,11 @@
+from django_filters import rest_framework as filters
+from web.datasets.models import Gazette
+
+
+class GazetteFilter(filters.FilterSet):
+    start_date = filters.DateFilter(field_name="date", lookup_expr="gte")
+    end_date = filters.DateFilter(field_name="date", lookup_expr="lte")
+
+    class Meta:
+        model = Gazette
+        fields = ["power", "start_date", "end_date"]

--- a/web/api/routes.py
+++ b/web/api/routes.py
@@ -1,17 +1,19 @@
-from django.urls import path
+from django.urls import include, path
 from rest_framework import routers
-
 from web.api.views import (
     CityCouncilAgendaView,
     CityCouncilAttendanceListView,
+    GazetteView,
     HealthCheckView,
 )
 
 router = routers.DefaultRouter()
+router.register("", HealthCheckView, basename="root")
+router.register("gazettes", GazetteView, basename="gazettes")
 
 
 urlpatterns = [
-    path("", HealthCheckView.as_view()),
+    path("", include(router.urls)),
     path(
         "city-council/agenda/",
         CityCouncilAgendaView.as_view(),

--- a/web/api/serializers.py
+++ b/web/api/serializers.py
@@ -1,6 +1,11 @@
 from rest_framework import serializers
-
-from web.datasets.models import CityCouncilAgenda, CityCouncilAttendanceList
+from web.datasets.models import (
+    CityCouncilAgenda,
+    CityCouncilAttendanceList,
+    File,
+    Gazette,
+    GazetteEvent,
+)
 
 
 class CityCouncilAgendaSerializer(serializers.ModelSerializer):
@@ -13,3 +18,31 @@ class CityCouncilAttendanceListSerializer(serializers.ModelSerializer):
     class Meta:
         model = CityCouncilAttendanceList
         fields = "__all__"
+
+
+class FileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = File
+        fields = ["url"]
+
+
+class GazetteEventSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GazetteEvent
+        fields = ["title", "secretariat", "summary", "published_on"]
+
+
+class GazetteSerializer(serializers.ModelSerializer):
+    events = GazetteEventSerializer(many=True)
+    files = FileSerializer(many=True)
+
+    class Meta:
+        model = Gazette
+        fields = [
+            "crawled_from",
+            "date",
+            "power",
+            "year_and_edition",
+            "events",
+            "files",
+        ]

--- a/web/api/tests/conftest.py
+++ b/web/api/tests/conftest.py
@@ -1,5 +1,8 @@
+from datetime import date
+
 import pytest
 from django.contrib.auth.models import User
+from model_bakery import baker
 from rest_framework.test import APIClient
 
 
@@ -22,3 +25,28 @@ def api_client_authenticated(api_client, user):
 @pytest.fixture
 def url():
     return "/api/"
+
+
+@pytest.fixture
+def one_gazette():
+    return baker.make_recipe("datasets.Gazette", date=date(2021, 4, 21))
+
+
+@pytest.fixture
+def last_of_two_gazettes():
+    baker.make_recipe("datasets.Gazette", date=date(2021, 3, 5))
+    return baker.make_recipe("datasets.Gazette", date=date(2021, 4, 21))
+
+
+@pytest.fixture
+def last_of_three_gazettes():
+    baker.make_recipe("datasets.Gazette", date=date(2021, 1, 1), power="executivo")
+    baker.make_recipe(
+        "datasets.GazetteEvent",
+        summary="Life? Don't talk to me about life.",
+        gazette__date=date(2021, 3, 5),
+        gazette__power="legislativo",
+    )
+    return baker.make_recipe(
+        "datasets.Gazette", date=date(2021, 4, 21), power="executivo"
+    )

--- a/web/api/tests/test_health_check.py
+++ b/web/api/tests/test_health_check.py
@@ -1,53 +1,25 @@
-import json
-from unittest import mock
-
 import pytest
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.test import APIRequestFactory, force_authenticate
-
-from web.api.views import HealthCheckView
+from django.urls import reverse
 
 
 class TestHealthCheck:
-    def get_restrict_permissions(self):
-        return [IsAuthenticated()]
-
-    @pytest.fixture
-    def mocked_get_permissions(self):
-        return mock.patch("web.api.views.HealthCheckView.get_permissions")
-
-    @pytest.fixture
-    def authenticated_request(self, url, user):
-        factory = APIRequestFactory()
-        request = factory.get(url)
-        request.user = user
-        force_authenticate(request, user)
-        return request
-
     def test_return_success_when_accessing_health_check(self, api_client, url):
         response = api_client.get(url, format="json")
         assert response.status_code == 200
         assert list(response.json().keys()) == ["status", "time"]
         assert response.json().get("status") == "available"
 
-    # TODO Ajustar este teste quando houver uma rota restrita
     def test_return_forbidden_when_trying_to_anonymously_access_a_restricted_route(
-        self, api_client, mocked_get_permissions
+        self, api_client
     ):
-        with mocked_get_permissions as mocked_view:
-            mocked_view.side_effect = self.get_restrict_permissions
-            response = api_client.get("/api/", format="json")
-            assert response.status_code == 403
+        url = reverse("gazettes-list")
+        response = api_client.get(url)
+        assert response.status_code == 403
 
-    # TODO Ajustar este teste quando houver uma rota restrita
+    @pytest.mark.django_db
     def test_return_success_when_accessing_a_restricted_route_with_credentials(
-        self, authenticated_request, mocked_get_permissions
+        self, api_client_authenticated
     ):
-        with mocked_get_permissions as mocked_view:
-            mocked_view.side_effect = self.get_restrict_permissions
-            view = HealthCheckView.as_view()
-            response = view(authenticated_request)
-            json_response = json.loads(response.rendered_content)
-            assert response.status_code == 200
-            assert list(json_response.keys()) == ["status", "time"]
-            assert json_response.get("status") == "available"
+        url = reverse("gazettes-list")
+        response = api_client_authenticated.get(url)
+        assert response.status_code == 200

--- a/web/api/views.py
+++ b/web/api/views.py
@@ -1,21 +1,24 @@
 from datetime import datetime
 
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.filters import SearchFilter
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from rest_framework.views import APIView
-
+from rest_framework.viewsets import ReadOnlyModelViewSet, ViewSet
+from web.api.filters import GazetteFilter
 from web.api.serializers import (
     CityCouncilAgendaSerializer,
     CityCouncilAttendanceListSerializer,
+    GazetteSerializer,
 )
-from web.datasets.models import CityCouncilAgenda, CityCouncilAttendanceList
+from web.datasets.models import CityCouncilAgenda, CityCouncilAttendanceList, Gazette
 
 
-class HealthCheckView(APIView):
+class HealthCheckView(ViewSet):
     permission_classes = [AllowAny]
 
-    def get(self, request):
+    def list(self, request):
         return Response({"status": "available", "time": datetime.now()})
 
 
@@ -61,3 +64,17 @@ class CityCouncilAttendanceListView(ListAPIView):
             kwargs["date__lte"] = end_date
 
         return self.queryset.filter(**kwargs)
+
+
+class GazetteView(ReadOnlyModelViewSet):
+    queryset = Gazette.objects.all()
+    serializer_class = GazetteSerializer
+    filterset_class = GazetteFilter
+    filter_backends = [SearchFilter, DjangoFilterBackend]
+    search_fields = [
+        "events__title",
+        "events__secretariat",
+        "events__summary",
+        "year_and_edition",
+        "files__search_vector",
+    ]

--- a/web/settings.py
+++ b/web/settings.py
@@ -111,9 +111,11 @@ class Common(Configuration):
 
     CITY_COUNCIL_WEBSERVICE = "http://teste-transparencia.com.br/"
 
-    BROKER_HOST = os.getenv("BROKER_HOST", "rabbitmq")
-    BROKER_PORT = os.getenv("BROKER_PORT", "5672")
-    BROKER_URL = f"amqp://{BROKER_HOST}:{BROKER_PORT}"
+    BROKER_HOST = values.Value(environ_prefix=None, default="rabbitmq")
+    BROKER_PORT = values.Value(environ_prefix=None, default="5672")
+    BROKER_USER = values.Value(environ_prefix=None, default="guest")
+    BROKER_PASSWORD = values.Value(environ_prefix=None, default="guest")
+    BROKER_VHOST = values.Value(environ_prefix=None, default="/")
 
     REST_FRAMEWORK = {
         "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
@@ -151,8 +153,6 @@ class Dev(Common):
 class Prod(Common):
     SECRET_KEY = values.SecretValue()
     ALLOWED_HOSTS = values.ListValue()
-    CLOUDAMQP_URL = values.Value(environ_prefix=None)
-    BROKER_URL = CLOUDAMQP_URL
     DATABASES = {"default": dj_database_url.config(conn_max_age=600, ssl_require=True)}
     GOOGLE_ANALYTICS_KEY = values.Value()
     CITY_COUNCIL_WEBSERVICE = values.Value()

--- a/web/settings.py
+++ b/web/settings.py
@@ -38,6 +38,7 @@ class Common(Configuration):
         "web.datasets.apps.DatasetsConfig",
         "rest_framework",
         "simple_history",
+        "django_filters",
     ]
 
     MIDDLEWARE = [
@@ -118,6 +119,10 @@ class Common(Configuration):
     BROKER_VHOST = values.Value(environ_prefix=None, default="/")
 
     REST_FRAMEWORK = {
+        "SEARCH_PARAM": "query",
+        "DEFAULT_FILTER_BACKENDS": [
+            "django_filters.rest_framework.DjangoFilterBackend"
+        ],
         "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
         "DEFAULT_AUTHENTICATION_CLASSES": (
             "rest_framework.authentication.SessionAuthentication",


### PR DESCRIPTION
Adiciona o endpoint para diários oficiais com opções de filtros via interface browseable do django rest framework.

A rota adicionada foi `api/gazettes`. Os filtros são feitos através que query string, e são eles:

- `query`: procura a palavra dentro do diários e dos eventos do diário
- `power`: filtra os diários pelo poder (executivo ou legislativo)
- `start`: filtra os diários que tenham a data maior ou igual à data especificada
- `end`: filtra os diários que tenham a data menor ou igual à data especificada

Os filtros podem ser combinados entre eles.