### PR TITLE
Medida para evitar mostrar informações do output do ssh-keyscan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,5 @@ jobs:
           branch: main
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
           git_remote_url: ${{ secrets.DOKKU_REMOTE_URL }}
+          ssh_host_key: ${{ secrets.SSH_HOST_KEY }}
     needs: [build]


### PR DESCRIPTION
[DadosAbertosDeFeira/iac#18](https://github.com/DadosAbertosDeFeira/iac/issues/18)

É necessário adicionar a secret `SSH_HOST_KEY` com o output do seguinte comando `ssh-keyscan -t rsa -p PORT HOST`

@gomex