### PR TITLE
Exclui registros em uma unica task

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-black==20.8b1
+black==21.7b0
 django-debug-toolbar==3.2.1
 flake8==3.9.2
 isort==5.9.3

--- a/scraper/spiders/citycouncil.py
+++ b/scraper/spiders/citycouncil.py
@@ -79,7 +79,7 @@ class AttendanceListSpider(BaseSpider):
 
     @staticmethod
     def get_status(status):
-        """"Retorna label dos status. Consultado em 06/08/2021."""
+        """Retorna label dos status. Consultado em 06/08/2021."""
         if not status:
             return ""
         status = strip_accents(status.strip())

--- a/web/datasets/management/commands/_citycouncil.py
+++ b/web/datasets/management/commands/_citycouncil.py
@@ -1,3 +1,4 @@
+from django.contrib.admin.options import get_content_type_for_model
 from web.datasets.management.commands._file import save_file
 from web.datasets.models import (
     CityCouncilAgenda,
@@ -5,7 +6,6 @@ from web.datasets.models import (
     CityCouncilExpense,
     CityCouncilMinute,
 )
-from django.contrib.admin.options import get_content_type_for_model
 
 
 def save_agenda(item):
@@ -26,7 +26,6 @@ def save_attendance_list(item):
         defaults={
             "crawled_at": item["crawled_at"],
             "crawled_from": item["crawled_from"],
-            "description": item["description"],
             "status": item.get("status"),
         },
     )

--- a/web/datasets/management/commands/citycouncil_sync.py
+++ b/web/datasets/management/commands/citycouncil_sync.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
 
         chain(
             get_city_council_updates.s(target_date.strftime("%Y-%m-%d")),
-            distribute_city_council_objects_to_sync.s(),
+            distribute_city_council_objects_to_sync.s(retry=False),
         )()
 
         self.stdout.write(

--- a/web/datasets/tasks.py
+++ b/web/datasets/tasks.py
@@ -123,7 +123,7 @@ def get_city_council_updates(formatted_date):
     return response
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def distribute_city_council_objects_to_sync(payload):
     """Recebe o payload e dispara uma task para cada registro.
 
@@ -156,7 +156,7 @@ def distribute_city_council_objects_to_sync(payload):
                 task.delay(record)
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def save_citycouncil_files(files, object, url_key):
     if not files:
         return
@@ -168,7 +168,7 @@ def save_citycouncil_files(files, object, url_key):
             save_file(file_[url_key], content_type, object.pk)
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def add_citycouncil_bid(record):
     new_item = to_citycouncil_bid(record)
     new_item["crawled_at"] = datetime.now()
@@ -180,8 +180,7 @@ def add_citycouncil_bid(record):
     return bid
 
 
-# TODO tentar novamente se não existe apenas
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def update_citycouncil_bid(record):
     bid = CityCouncilBid.objects.get(external_code=record["codLic"])
     updated_item = to_citycouncil_bid(record)
@@ -193,13 +192,13 @@ def update_citycouncil_bid(record):
     return bid
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def remove_citycouncil_bid(records: List[dict]):
     to_be_removed = [record["codLic"] for record in records]
     CityCouncilBid.objects.filter(external_code__in=to_be_removed).update(excluded=True)
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def add_citycouncil_contract(record):
     new_item = to_citycouncil_contract(record)
     new_item["crawled_at"] = datetime.now()
@@ -211,7 +210,7 @@ def add_citycouncil_contract(record):
     return contract
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def update_citycouncil_contract(record):
     contract = CityCouncilContract.objects.get(external_code=record["codCon"])
     updated_item = to_citycouncil_contract(record)
@@ -223,7 +222,7 @@ def update_citycouncil_contract(record):
     return contract
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def remove_citycouncil_contract(records: List[dict]):
     to_be_removed = [record["codCon"] for record in records]
     CityCouncilContract.objects.filter(external_code__in=to_be_removed).update(
@@ -231,7 +230,7 @@ def remove_citycouncil_contract(records: List[dict]):
     )
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def add_citycouncil_revenue(record):
     new_item = to_citycouncil_revenue(record)
     new_item["crawled_at"] = datetime.now()
@@ -242,7 +241,7 @@ def add_citycouncil_revenue(record):
     return revenue
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def update_citycouncil_revenue(record):
     revenue = CityCouncilRevenue.objects.get(external_code=record["codLinha"])
     updated_item = to_citycouncil_revenue(record)
@@ -252,7 +251,7 @@ def update_citycouncil_revenue(record):
     return revenue
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def remove_citycouncil_revenue(records: List[dict]):
     to_be_removed = [record["codLinha"] for record in records]
     CityCouncilRevenue.objects.filter(external_code__in=to_be_removed).update(
@@ -260,7 +259,7 @@ def remove_citycouncil_revenue(records: List[dict]):
     )
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def add_citycouncil_expense(record):
     new_item = to_citycouncil_expense(record)
     new_item["crawled_at"] = datetime.now()
@@ -275,7 +274,7 @@ def add_citycouncil_expense(record):
     return expense
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def update_citycouncil_expense(record):
     expense = CityCouncilExpense.objects.get(
         external_file_code=record["codArquivo"],
@@ -288,7 +287,7 @@ def update_citycouncil_expense(record):
     return expense
 
 
-@shared_task(retry_kwargs={"max_retries": 1})
+@shared_task(retry_kwargs={"max_retries": 1}, ignore_result=True)
 def remove_citycouncil_expense(records: List[dict]):
     for record in records:
         CityCouncilExpense.objects.filter(

--- a/web/datasets/tests/management/commands/test_citycouncil.py
+++ b/web/datasets/tests/management/commands/test_citycouncil.py
@@ -2,7 +2,6 @@ from datetime import date, datetime
 
 import pytest
 from django.utils.timezone import make_aware
-
 from web.datasets.management.commands._citycouncil import (
     save_agenda,
     save_attendance_list,
@@ -72,7 +71,6 @@ class TestSaveAttendanceList:
     def test_save_attendance_list(self):
         item = {
             "date": date(2020, 2, 3),
-            "description": "Abertura da 1ª etapa do 4º período da 18ª legislatura",
             "council_member": "Roberto Luis da Silva Tourinho",
             "status": "presente",
             "crawled_at": make_aware(datetime(2020, 3, 21, 7, 15, 17, 276019)),
@@ -81,7 +79,6 @@ class TestSaveAttendanceList:
 
         attendance = save_attendance_list(item)
         assert attendance.date == item["date"]
-        assert attendance.description == item["description"]
         assert attendance.council_member == item["council_member"]
         assert attendance.status == item["status"]
         assert attendance.crawled_at == item["crawled_at"]

--- a/web/datasets/tests/test_tasks.py
+++ b/web/datasets/tests/test_tasks.py
@@ -359,14 +359,13 @@ class TestCityCouncilBid:
         assert updated_bid.excluded is False
 
     def test_remove_citycouncil_bid(self):
-        bid = baker.make_recipe(
-            "datasets.CityCouncilBid", external_code=214, excluded=False
-        )
-        record = {"codLic": "214"}
+        bids = baker.make_recipe("datasets.CityCouncilBid", excluded=False, _quantity=3)
+        record = [{"codLic": bid.external_code} for bid in bids]
         remove_citycouncil_bid.delay(record)
 
-        bid.refresh_from_db()
-        assert bid.excluded is True
+        for bid in bids:
+            bid.refresh_from_db()
+            assert bid.excluded is True
 
     def test_update_citycouncil_files(self, mock_save_file):
         bid = baker.make_recipe("datasets.CityCouncilBid", external_code=214)
@@ -520,15 +519,16 @@ class TestCityCouncilContract:
         assert contract.pk == updated_contract.pk
         assert updated_contract.files.count() == 1
 
-    def test_remove_citycouncil_contract(self):
-        contract = baker.make_recipe(
-            "datasets.CityCouncilContract", external_code=214, excluded=False
+    def test_remove_citycouncil_contracts(self):
+        contracts = baker.make_recipe(
+            "datasets.CityCouncilContract", excluded=False, _quantity=3
         )
-        record = {"codCon": "214"}
-        remove_citycouncil_contract.delay(record)
+        records = [{"codCon": contract.external_code} for contract in contracts]
+        remove_citycouncil_contract.delay(records)
 
-        contract.refresh_from_db()
-        assert contract.excluded is True
+        for contract in contracts:
+            contract.refresh_from_db()
+            assert contract.excluded is True
 
 
 @pytest.mark.django_db
@@ -625,14 +625,15 @@ class TestCityCouncilRevenue:
         assert revenue.pk == updated_revenue.pk
 
     def test_remove_citycouncil_revenue(self):
-        revenue = baker.make_recipe(
-            "datasets.CityCouncilRevenue", external_code=214, excluded=False
+        revenues = baker.make_recipe(
+            "datasets.CityCouncilRevenue", excluded=False, _quantity=3
         )
-        record = {"codLinha": "214"}
-        remove_citycouncil_revenue.delay(record)
+        records = [{"codLinha": revenue.external_code} for revenue in revenues]
+        remove_citycouncil_revenue.delay(records)
 
-        revenue.refresh_from_db()
-        assert revenue.excluded is True
+        for revenue in revenues:
+            revenue.refresh_from_db()
+            assert revenue.excluded is True
 
 
 @pytest.mark.django_db
@@ -776,14 +777,15 @@ class TestCityCouncilExpense:
         assert expense.pk == updated_expense.pk
 
     def test_remove_citycouncil_expense(self):
-        expense = baker.make_recipe(
-            "datasets.CityCouncilExpense",
-            external_file_code=253,
-            external_file_line=2,
-            excluded=False,
+        expenses = baker.make_recipe(
+            "datasets.CityCouncilExpense", excluded=False, _quantity=3
         )
-        record = {"codigo": "253", "linha": "2"}
-        remove_citycouncil_expense.delay(record)
+        records = [
+            {"codigo": expense.external_file_code, "linha": expense.external_file_line}
+            for expense in expenses
+        ]
+        remove_citycouncil_expense.delay(records)
 
-        expense.refresh_from_db()
-        assert expense.excluded is True
+        for expense in expenses:
+            expense.refresh_from_db()
+            assert expense.excluded is True


### PR DESCRIPTION
Estamos atingindo o limite em nossa conta do CloudAMQP. Esse PR visa tentar reduzir o número de tasks geradas.
