### PR TITLE
Remove tasks de heartbeat, mingle e gossip do celery

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: bin/release.sh
 web: gunicorn web.wsgi:application --preload --log-file -
-worker: celery -A web worker -l INFO
+worker: celery -A web worker -l INFO --without-heartbeat --without-gossip --without-mingle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
     worker:
         build: .
-        command: ["celery", "-A", "web", "worker", "-l", "INFO"]
+        command: ["celery", "-A", "web", "worker", "-l", "INFO", "--without-heartbeat", "--without-gossip", "--without-mingle"]
         environment:
             DATABASE_HOST: db
             TIKA_CLIENT_ONLY: 1

--- a/web/datasets/management/commands/citycouncil_sync.py
+++ b/web/datasets/management/commands/citycouncil_sync.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
 
         chain(
             get_city_council_updates.s(target_date.strftime("%Y-%m-%d")),
-            distribute_city_council_objects_to_sync.s(retry=False),
+            distribute_city_council_objects_to_sync.s(),
         )()
 
         self.stdout.write(


### PR DESCRIPTION
Seguindo o conselho do CloudAMQP, após estouro na capacidade do plano grátis:

>  PS: If you're using Celery, make sure that you add --without-gossip --without-mingle --without-heartbeat to the Celery worker command line arguments. More Celery specific information can be found here.
