### PR TITLE
Salva conteúdo como vazio quando PDF é uma imagem

### DIFF
--- a/web/datasets/tasks.py
+++ b/web/datasets/tasks.py
@@ -57,8 +57,9 @@ def content_from_file(file_pk=None, path=None, keep_file=True):
         Path(path).unlink()
 
     if a_file:
-        a_file.content = raw["content"]
+        a_file.content = raw["content"] or ""
         a_file.save()
+        return a_file.content
 
     return raw["content"]
 


### PR DESCRIPTION
Atualmente a criação de tasks fica em loop infinito porque o signal sempre tenta extrair o conteúdo quando nada é retornado pelo Tika.