### PR TITLE
Pins jsonschema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ djangorestframework-simplejwt==4.8.0
 gunicorn==20.1.0
 https://github.com/DadosAbertosDeFeira/tcm-ba/releases/download/0.2.0/documentos_tcmba-0.2.0-py3-none-any.whl
 jinja2==3.0.1
+jsonschema==3.2.0
 newrelic==7.0.0.166
 psycopg2-binary==2.9.1
 python-dateutil==2.8.2


### PR DESCRIPTION
`jsonschema` is a `spidermon` dependency. `jsonschema` version 4 was released 4 days ago, but it is not backward compatible, causing `spidermon` to fail with `ModuleNotFoundError: No module named 'jsonschema.compat'`.

Unitl `spidermon` handles that, we might need to pin this dependency of a dependency version to version 3.