### PR TITLE
Fixes Django Debug Toolbar in Docker

### DIFF
--- a/web/settings.py
+++ b/web/settings.py
@@ -1,6 +1,6 @@
 import os
 from datetime import timedelta
-from socket import gethostbyname, gethostname
+from socket import gethostbyname, gethostbyname_ex, gethostname
 
 import dj_database_url
 import sentry_sdk
@@ -158,7 +158,8 @@ class Dev(Common):
 
     MIDDLEWARE = Common.MIDDLEWARE + ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 
-    INTERNAL_IPS = ["127.0.0.1"]
+    hostname, _, ips = gethostbyname_ex(gethostname())
+    INTERNAL_IPS = ["127.0.0.1"] + [ip[:-1] + "1" for ip in ips]
 
 
 class Test(Dev):


### PR DESCRIPTION
O _Django Debug Toolbar_ não estava carregando pois ele só funciona em um IP “interno” — ou seja, um IP listado em `web.settings.INTERNAL_IPS`. Manulamente incluíamos o famoso `127.0.0.1` nessa configuração, mas rodando do Docker, o IP é outro (pois é um IP da rede interna do Docker).

Para contornar a situação, usamos o pacote `socket` para detectar os IPs internos da rede do Docker e agora o Django Debug Toolbar carrega em desenvolvimento :tada:

![image](https://user-images.githubusercontent.com/4732915/136867001-4e855d81-ad55-4423-9b4d-290db532b1c3.png)
