### PR TITLE
Adiciona etapa nas instruções do projeto para evitar que testes falhem

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ make build
 ```
 
 O passo anterior vai criar um banco de dados postgres.
-Agora, basta aplicar as `migrations`:
+Agora, basta aplicar as `migrations` executar o `collectstatic`:
 
 ```
 make migrate
+make collectstatic
 ```
 
 ### Executando os testes


### PR DESCRIPTION
Ao seguir as instruções do projeto no `README.md` e rodar os testes, os testes falham pois não existem arquivos estáticos ainda.

Adicionei a etapa de coleta desses arquivos junto com a de migrações do banco de dados, assim quem seguir as instruções não se depara com erros nas primeiras tentativas.
