### PR TITLE
Adiciona `datasets/` aos endpoints relacionados a bases de dados

### DIFF
--- a/web/api/constants.py
+++ b/web/api/constants.py
@@ -1,6 +1,6 @@
-GAZZETES_API = "api/gazettes"
-CITY_HALL_API = "api/city-hall"
-CITY_COUNCIL_API = "api/city-council"
+GAZETTES_API = "api/datasets/gazettes"
+CITY_HALL_API = "api/datasets/city-hall"
+CITY_COUNCIL_API = "api/datasets/city-council"
 
 AVAILABLE_ENDPOINTS_BY_PUBLIC_AGENCY = {
     "city-council": {
@@ -16,7 +16,7 @@ AVAILABLE_ENDPOINTS_BY_PUBLIC_AGENCY = {
             },
             {
                 "friendly_name": "Diário Oficial - Legislativo",
-                "endpoint": f"{GAZZETES_API}/?power=legislative",
+                "endpoint": f"{GAZETTES_API}/?power=legislative",
             },
             {
                 "friendly_name": "Lista de presença dos vereadores",
@@ -29,7 +29,7 @@ AVAILABLE_ENDPOINTS_BY_PUBLIC_AGENCY = {
         "endpoints": [
             {
                 "friendly_name": "Diário Oficial - Executivo",
-                "endpoint": f"{GAZZETES_API}/?power=executive",
+                "endpoint": f"{GAZETTES_API}/?power=executive",
             },
             {
                 "friendly_name": "Licitações",

--- a/web/api/routes.py
+++ b/web/api/routes.py
@@ -13,26 +13,26 @@ from web.api.views import (
 
 router = routers.DefaultRouter()
 router.register("", HealthCheckView, basename="root")
-router.register("gazettes", GazetteView, basename="gazettes")
+router.register("datasets/gazettes", GazetteView, basename="gazettes")
 
 
 urlpatterns = [
     path("", include(router.urls)),
     path(
-        "city-council/agenda/",
+        "datasets/city-council/agenda/",
         CityCouncilAgendaView.as_view(),
         name="city-council-agenda",
     ),
     path(
-        "city-council/attendance-list/",
+        "datasets/city-council/attendance-list/",
         CityCouncilAttendanceListView.as_view(),
         name="city-council-attendance-list",
     ),
     path(
-        "city-council/minute/",
+        "datasets/city-council/minute/",
         CityCouncilMinuteView.as_view(),
         name="city-council-minute",
     ),
-    path("city-hall/bids/", CityHallBidView.as_view(), name="city-hall-bids"),
-    path("endpoints", FrontendEndpoint.as_view(), name="frontend-endpoints"),
+    path("datasets/city-hall/bids/", CityHallBidView.as_view(), name="city-hall-bids"),
+    path("datasets/endpoints", FrontendEndpoint.as_view(), name="frontend-endpoints"),
 ]

--- a/web/api/tests/constants.py
+++ b/web/api/tests/constants.py
@@ -1,6 +1,6 @@
-GAZZETES_API = "api/gazettes"
-CITY_HALL_API = "api/city-hall"
-CITY_COUNCIL_API = "api/city-council"
+GAZZETES_API = "api/datasets/gazettes"
+CITY_HALL_API = "api/datasets/city-hall"
+CITY_COUNCIL_API = "api/datasets/city-council"
 
 AVAILABLE_ENDPOINTS_BY_PUBLIC_AGENCY = {
     "city-council": {


### PR DESCRIPTION
Olhando nossa API de maneira geral senti que seria bom termos `api/datasets` na URL para indicar acesso as bases de dados. Dessa forma acredito ficar menos confuso para quem vai trabalhar no frontend.
